### PR TITLE
Sd-config path and status

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -11,13 +11,16 @@ import (
 // GetLocation handles the request to redirect to the active Ceph managed Prometheus server
 // It retrieves the active host URL and appends any query parameters from the request.
 func GetLocation(c *fiber.Ctx) error {
-	hostUrl, _, err := getHostUrl()
+	var header string = "http://"
+
+	url, _, err := getHostUrl()
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to retrieve Ceph managed Prometheus server URL",
 		})
 	}
 
+	hostUrl := header + url
 	qparms := c.Queries()
 	if len(qparms) > 0 {
 		// If there are query parameters, append them to the host URL.
@@ -25,6 +28,10 @@ func GetLocation(c *fiber.Ctx) error {
 		for key, value := range qparms {
 			hostUrl += key + "=" + value + "&"
 		}
+	}
+
+	if config.Debug {
+		log.Printf("Redirecting to active Ceph managed Prometheus server: %s\n", hostUrl)
 	}
 
 	return c.Redirect(hostUrl, fiber.StatusFound)

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -9,15 +9,25 @@ import (
 )
 
 // GetLocation handles the request to redirect to the active Ceph managed Prometheus server
+// It retrieves the active host URL and appends any query parameters from the request.
 func GetLocation(c *fiber.Ctx) error {
-	serverUrl, _, err := getHostUrl()
+	hostUrl, _, err := getHostUrl()
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to retrieve Ceph managed Prometheus server URL",
 		})
 	}
 
-	return c.Redirect(serverUrl, fiber.StatusFound)
+	qparms := c.Queries()
+	if len(qparms) > 0 {
+		// If there are query parameters, append them to the host URL.
+		hostUrl += "?"
+		for key, value := range qparms {
+			hostUrl += key + "=" + value + "&"
+		}
+	}
+
+	return c.Redirect(hostUrl, fiber.StatusFound)
 }
 
 func getHostUrl() (string, bool, error) {

--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -37,6 +37,26 @@ func GetLocation(c *fiber.Ctx) error {
 	return c.Redirect(hostUrl, fiber.StatusFound)
 }
 
+func GetActiveHost(c *fiber.Ctx) error {
+	// This function is similar to GetLocation but returns the active host URL without redirecting.
+	url, running, err := getHostUrl()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to retrieve Ceph managed Prometheus server URL",
+		})
+	}
+
+	if !running {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "No active Ceph managed Prometheus server found",
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"url": url,
+	})
+}
+
 func getHostUrl() (string, bool, error) {
 	activeHostUrl, running, err := cephlocator.GetActiveHost()
 	if err != nil {

--- a/router/router.go
+++ b/router/router.go
@@ -17,7 +17,8 @@ func SetupRoutes(app *fiber.App) {
 
 	// API routes
 	api := app.Group("/api/v1/", logger.New())
-	api.Get("/", v1.GetLocation)
+	api.Get("/", v1.GetActiveHost)
+	api.Get("status", v1.GetActiveHost)
 
 	// SD Path
 	sdPath := app.Group("/sd/prometheus/", logger.New())

--- a/router/router.go
+++ b/router/router.go
@@ -20,6 +20,6 @@ func SetupRoutes(app *fiber.App) {
 	api.Get("/", v1.GetLocation)
 
 	// SD Path
-	sdPath := app.Group("/sd/prometheus/")
+	sdPath := app.Group("/sd/prometheus/", logger.New())
 	sdPath.Get("sd-config", v1.GetLocation)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -18,4 +18,8 @@ func SetupRoutes(app *fiber.App) {
 	// API routes
 	api := app.Group("/api/v1/", logger.New())
 	api.Get("/", v1.GetLocation)
+
+	// SD Path
+	sdPath := app.Group("/sd/prometheus/")
+	sdPath.Get("sd-config", v1.GetLocation)
 }


### PR DESCRIPTION
Turns out I need be allowing a incoming request similar to `/sd/prometheus/sd-config?service=node-exporter` and passing the correct query parameter to the redirect url. This branch solves that issue and also adds a status endpoint. 